### PR TITLE
fix: invalidate cached userData preventing refresh

### DIFF
--- a/src/components/reusable/LoginForm.tsx
+++ b/src/components/reusable/LoginForm.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { cn } from '@/lib/utils'
 
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { login } from '@/api/user'
 import { loginSchema } from '@/schemas/login'
 import { loginSchemaType } from '@/types'
@@ -25,6 +25,7 @@ const LoginForm: React.FC<React.ComponentPropsWithoutRef<'div'>> = ({
   ...props
 }) => {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
 
   const {
     register,
@@ -40,6 +41,8 @@ const LoginForm: React.FC<React.ComponentPropsWithoutRef<'div'>> = ({
       return login({ email, password })
     },
     onSuccess: () => {
+      // should probably limit to query key 'user'
+      queryClient.invalidateQueries()
       navigate({
         to: '/',
       })

--- a/src/components/reusable/LoginForm.tsx
+++ b/src/components/reusable/LoginForm.tsx
@@ -42,7 +42,7 @@ const LoginForm: React.FC<React.ComponentPropsWithoutRef<'div'>> = ({
     },
     onSuccess: () => {
       // should probably limit to query key 'user'
-      queryClient.invalidateQueries()
+      queryClient.invalidateQueries({queryKey: ['user']})
       navigate({
         to: '/',
       })


### PR DESCRIPTION
The cached userData was being retrieved which was empty when you first went to the login page. Invalidating that query allows for the userData to be fetched again once the token is set and correctly retrieve the userData and allow the navigation.

This might not be the correct place to invalidate the cached data but I am not super familiar with Tanstack QueryClient or Router. This does correct the issue and allow for redirect after the login.