### PR TITLE
#20 omit password field from user

### DIFF
--- a/server/src/db/init.ts
+++ b/server/src/db/init.ts
@@ -1,6 +1,12 @@
 import { PrismaClient } from '@prisma/client'
 
-export const prisma = new PrismaClient()
+const prisma = new PrismaClient({
+  omit: {
+    user: {
+      password: true,
+    },
+  },
+})
 
 type QueryFunc = () => Promise<unknown>
 


### PR DESCRIPTION
Prevents prisma from exposing the password field to `user` objects return from the DB unless explicitly specified. Ref #20